### PR TITLE
just an idea how to make steps more versatile

### DIFF
--- a/src/Entity/Process/Loop.php
+++ b/src/Entity/Process/Loop.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of a Spipu Bundle
+ *
+ * (c) Laurent Minguet
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Spipu\ProcessBundle\Entity\Process;
+
+class Loop
+{
+    private string $code;
+    private array $steps;
+    private Parameters $parameters;
+    private bool $ignoreInProgress;
+
+    public function __construct(
+        string $code,
+        array $steps,
+        Parameters $parameters,
+        bool $ignoreInProgress
+    ) {
+        $this->code = $code;
+        $this->steps = $steps;
+        $this->parameters = $parameters;
+        $this->ignoreInProgress = $ignoreInProgress;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getSteps(): array
+    {
+        return $this->steps;
+    }
+
+    public function getParameters(): Parameters
+    {
+        return $this->parameters;
+    }
+
+    public function isIgnoreInProgress(): bool
+    {
+        return $this->ignoreInProgress;
+    }
+}

--- a/src/Service/ProcessManager.php
+++ b/src/Service/ProcessManager.php
@@ -141,8 +141,16 @@ class ProcessManager
         return $steps;
     }
 
-    private function loadPrepareStep(array $stepDefinition): Process\Step
+    private function loadPrepareStep(array $stepDefinition): Process\Step|Process\Loop
     {
+        if (!isset($stepDefinition['class']) && isset($stepDefinition['steps'])) {
+            return new Process\Loop(
+                $stepDefinition['code'],
+                $this->loadPrepareSteps($stepDefinition),
+                $this->loadPrepareParameters($stepDefinition['parameters']),
+                $stepDefinition['ignore_in_progress']
+            );
+        }
         return new Process\Step(
             $stepDefinition['code'],
             $this->configReader->getStepClassFromClassname($stepDefinition['class']),
@@ -397,27 +405,51 @@ class ProcessManager
                 $kSteps++;
             }
             $logger->setCurrentStep(max($kSteps, 0), $step->isIgnoreInProgress());
-            $logger->info(sprintf('Step [%s]', $step->getCode()));
-
-            $stepProcessor = $step->getProcessor();
-
-            $message = 'Step [' . $step->getCode() . ']';
-            $this->reportManager->addProcessReportWarning($process, $message);
-            $this->reportManager->addReportToStep($stepProcessor, $process->getReport());
-
-            $startTime = microtime(true);
-            $result = $stepProcessor->execute($step->getParameters(), $logger);
-            $deltaTime = microtime(true) - $startTime;
-
-            $message = 'Step executed in ' . number_format($deltaTime, 3, '.', '') . ' ms';
-            $this->reportManager->addProcessReportMessage($process, $message);
-            $this->reportManager->addReportToStep($stepProcessor, null);
-
-            $process->getParameters()->set('time.' . $step->getCode(), $deltaTime);
-            $process->getParameters()->set('result.' . $step->getCode(), $result);
+            $result = $this->executeStep($process, $step, $logger);
         }
         $kSteps++;
         $logger->setCurrentStep($kSteps, false);
+
+        return $result;
+    }
+
+    private function executeStep(Process\Process $process, Process\Step|Process\Loop $step, LoggerProcessInterface $logger): mixed
+    {
+        $result = null;
+        $logger->info(sprintf('Step [%s]', $step->getCode()));
+
+        if ($step instanceof Process\Loop) {
+            $iterable = $step->getParameters()->get('iterable');
+            if (!is_iterable($iterable)) {
+                return null;
+            }
+            foreach ($iterable as $key => $value) {
+                $logger->info('⭯ Iteration key: [' . $key . ']');
+                $process->getParameters()->set('loop.' . $step->getCode(), $value);
+                foreach ($step->getSteps() as $subStep) {
+                    $subStep->getParameters()->setParentParameters($step->getParameters());
+                    $result = $this->executeStep($process, $subStep, $logger);
+                }
+            }
+            return $result;
+        }
+
+        $stepProcessor = $step->getProcessor();
+
+        $message = 'Step [' . $step->getCode() . ']';
+        $this->reportManager->addProcessReportWarning($process, $message);
+        $this->reportManager->addReportToStep($stepProcessor, $process->getReport());
+
+        $startTime = microtime(true);
+        $result = $stepProcessor->execute($step->getParameters(), $logger);
+        $deltaTime = microtime(true) - $startTime;
+
+        $message = 'Step executed in ' . number_format($deltaTime, 3, '.', '') . ' ms';
+        $this->reportManager->addProcessReportMessage($process, $message);
+        $this->reportManager->addReportToStep($stepProcessor, null);
+
+        $process->getParameters()->set('time.' . $step->getCode(), $deltaTime);
+        $process->getParameters()->set('result.' . $step->getCode(), $result);
 
         return $result;
     }

--- a/src/SpipuProcessBundle.php
+++ b/src/SpipuProcessBundle.php
@@ -107,13 +107,33 @@ class SpipuProcessBundle extends AbstractBundle
                             ->append($this->addParametersNode())
                             ->children()
                                 ->scalarNode('class')
-                                    ->isRequired()
                                     ->cannotBeEmpty()
                                 ->end()
                             ->end()
                             ->children()
                                 ->booleanNode('ignore_in_progress')
                                     ->defaultFalse()
+                                ->end()
+                            ->end()
+                            ->children()
+                                ->arrayNode('steps')
+                                    ->requiresAtLeastOneElement()
+                                    ->normalizeKeys(true)
+                                    ->useAttributeAsKey('code')
+                                    ->arrayPrototype()
+                                        ->append($this->addParametersNode())
+                                        ->children()
+                                            ->scalarNode('class')
+                                                ->isRequired()
+                                                ->cannotBeEmpty()
+                                            ->end()
+                                        ->end()
+                                        ->children()
+                                            ->booleanNode('ignore_in_progress')
+                                                ->defaultFalse()
+                                            ->end()
+                                        ->end()
+                                    ->end()
                                 ->end()
                             ->end()
                         ->end()
@@ -194,6 +214,11 @@ class SpipuProcessBundle extends AbstractBundle
 
         foreach ($process['steps'] as $stepCode => &$step) {
             $step['code'] = $stepCode;
+            if (isset($step['steps'])) {
+                foreach ($step['steps'] as $stepStepCode => &$stepStep) {
+                    $stepStep['code'] = $stepStepCode;
+                }
+            }
         }
 
         return $process;


### PR DESCRIPTION
```yaml
spipu_process:
    test_loop:
        name: "Test Loop"

        options:
            can_be_put_in_queue: true
            can_be_rerun_automatically: false
            process_lock:
                - "test_loop"

        parameters:
            loop_source: ["Mercury", "Venus", "Mars", "Jupiter", "Saturn", "Uranus", "Earth"]

        steps:
            hello_world:
                class: Spipu\ProcessBundle\Step\Test\HelloWorld
                parameters:
                    name_from: "Foo"
                    name_to:   "Bar"

            hello_loop:
                parameters:
                    iterable: "{{ loop_source }}"
                steps:
                    hello_world_1:
                        class: Spipu\ProcessBundle\Step\Test\HelloWorld
                        parameters:
                            name_from: "{{ loop.hello_loop }}"
                            name_to: "The Moon"

                    hello_world_2:
                        class: Spipu\ProcessBundle\Step\Test\HelloWorld
                        parameters:
                            name_from: "\"{{ result.hello_world_1 }}\""
                            name_to: "{{ loop.hello_loop }}"

```

<img width="1277" height="2489" alt="image" src="https://github.com/user-attachments/assets/d4e7b9f7-a0ea-43cd-b56f-83c08de82f14" />
